### PR TITLE
feat(sherlock): support SettableDerivables in flatMap

### DIFF
--- a/libs/sherlock/src/lib/derivable/mixins/flat-map.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/flat-map.ts
@@ -1,6 +1,25 @@
-import { Derivable, Unwrappable } from '../../interfaces';
+import { Derivable, SettableDerivable, Unwrappable } from '../../interfaces';
+import { augmentStack } from '../../utils';
+import { lens } from '../factories';
+import { isSettableDerivable } from '../typeguards';
 import { unwrap } from '../unwrap';
 
+export function flatMapMethod<V, T>(
+    this: Derivable<V>,
+    deriver: (value: V) => SettableDerivable<T>,
+): SettableDerivable<T>;
+export function flatMapMethod<V, T>(this: Derivable<V>, deriver: (value: V) => Unwrappable<T>): Derivable<T>;
 export function flatMapMethod<V, T>(this: Derivable<V>, deriver: (value: V) => Unwrappable<T>): Derivable<T> {
-    return this.map(deriver).derive(unwrap);
+    return lens<T, [Unwrappable<T>]>(
+        {
+            get: unwrap,
+            set(value: T, base) {
+                if (!isSettableDerivable(base)) {
+                    throw augmentStack(new Error('The resulting Derivable from flatMap is not settable'), this);
+                }
+                base.set(value);
+            },
+        },
+        this.map(deriver),
+    );
 }

--- a/libs/sherlock/src/lib/interfaces.ts
+++ b/libs/sherlock/src/lib/interfaces.ts
@@ -76,6 +76,7 @@ export interface Derivable<V> {
     map<R>(f: (v: V) => MaybeFinalState<R>): Derivable<R>;
     mapState<R>(f: (v: State<V>) => MaybeFinalState<R>): Derivable<R>;
 
+    flatMap<R>(f: (v: V) => SettableDerivable<R>): SettableDerivable<R>;
     flatMap<R>(f: (v: V) => Unwrappable<R>): Derivable<R>;
 
     take(options: Partial<TakeOptions<V>>): Derivable<V>;


### PR DESCRIPTION
When using `flatMap` to map to a `SettableDerivable`, the resulting `Derivable` will also be settable.

Example:
```typescript
const atoms = ['a', 'b', 'c'].map(atom);
const switcher$ = atom(0);
const mappedDerivable$ = switcher$.flatMap(n => atoms[n]);
atoms[0].get(); // => 'a'
d$.set('d');
atoms[0].get(); // => 'd'
```