### PR TITLE
fix(sherlock-utils): derivableCache incorrectly reuses cached results…

### DIFF
--- a/libs/sherlock-utils/src/lib/derivable-cache.test.ts
+++ b/libs/sherlock-utils/src/lib/derivable-cache.test.ts
@@ -62,6 +62,22 @@ describe('sherlock-utils/derivableCache', () => {
         expect(result.dependencyCount).toBe(1);
     });
 
+    it('should support a combination of derivable and non derivable inputs', () => {
+        const repeated = derivableCache({ derivableFactory: (v: string) => constant(v + v), delayedEviction: true });
+        const derivableInput$ = atom('abc');
+        const derivableOutput$ = repeated(derivableInput$);
+
+        expect(derivableOutput$.get()).toBe('abcabc');
+
+        const constOutput$ = repeated('abc');
+        expect(constOutput$.get()).toBe('abcabc');
+
+        derivableInput$.set('def');
+
+        expect(derivableOutput$.get()).toBe('defdef');
+        expect(constOutput$.get()).toBe('abcabc');
+    });
+
     describe('(using the default JavaScript map implementation)', () => {
         let derivableFactory: jest.Mock;
         let resultCache: DerivableCache<string, string>;

--- a/libs/sherlock-utils/src/lib/derivable-cache.ts
+++ b/libs/sherlock-utils/src/lib/derivable-cache.ts
@@ -82,15 +82,18 @@ export function derivableCache<K, V>(opts: DerivableCacheOptions<K, V>): Derivab
         },
     };
 
-    return key => {
-        if (!isDerivable(key)) {
-            const cacheItem = cache.get(key);
-            if (cacheItem) {
-                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                return cacheItem[CACHED_PROXY]!;
-            }
+    function derivableCache(key: Unwrappable<K>): SettableDerivable<V> {
+        if (isDerivable(key)) {
+            return key.flatMap(derivableCache);
+        }
+        const cacheItem = cache.get(key);
+        if (cacheItem) {
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            return cacheItem[CACHED_PROXY]!;
         }
 
         return lens(descriptor, key);
-    };
+    }
+
+    return derivableCache;
 }


### PR DESCRIPTION
… when mixing Derivables and non-Derivables as input