### PR TITLE
fix(sherlock): fix subtle typing-bugs because of newer TypeScript features

### DIFF
--- a/libs/ngx-sherlock/src/lib/value.pipe.test.ts
+++ b/libs/ngx-sherlock/src/lib/value.pipe.test.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectorRef } from '@angular/core';
+import type { ChangeDetectorRef } from '@angular/core';
 import { atom, DerivableAtom } from '@skunkteam/sherlock';
 import { ValuePipe } from './value.pipe';
 

--- a/libs/sherlock-utils/src/lib/lift.test.ts
+++ b/libs/sherlock-utils/src/lib/lift.test.ts
@@ -1,4 +1,4 @@
-import { constant } from '@skunkteam/sherlock';
+import { constant, ErrorWrapper, FinalWrapper, unresolved } from '@skunkteam/sherlock';
 import { lift } from './lift';
 
 describe('sherlock-utils/lift', () => {
@@ -28,5 +28,11 @@ describe('sherlock-utils/lift', () => {
         const h = lift(triadic);
         expect(h(a$, n$, b$).get()).toBe('triadic (a,123,b)');
         expect(h('a', n$, b$).get()).toBe('triadic (a,123,b)');
+    });
+
+    it('should support non-value states', () => {
+        expect(lift(() => unresolved)().resolved).toBeFalse();
+        expect(lift(() => new ErrorWrapper('error'))().error).toBe('error');
+        expect(lift(() => FinalWrapper.wrap('value'))().final).toBeTrue;
     });
 });

--- a/libs/sherlock-utils/src/lib/lift.ts
+++ b/libs/sherlock-utils/src/lib/lift.ts
@@ -1,4 +1,4 @@
-import { Derivable, _internal } from '@skunkteam/sherlock';
+import { Derivable, derive, MaybeFinalState, unwrap, UnwrappableTuple } from '@skunkteam/sherlock';
 
 /**
  * Lifts the function f into a function over Derivables returning a Derivable, for example:
@@ -10,15 +10,10 @@ import { Derivable, _internal } from '@skunkteam/sherlock';
  *
  * @param f the function to lift into a function over Derivables
  */
-export function lift<R>(f: () => R): () => Derivable<R>;
-export function lift<P1, R>(f: (p1: P1) => R): (p1: MD<P1>) => Derivable<R>;
-export function lift<P1, P2, R>(f: (p1: P1, p2: P2) => R): (p1: MD<P1>, p2: MD<P2>) => Derivable<R>;
-export function lift<P1, P2, P3, R>(
-    f: (p1: P1, p2: P2, p3: P3) => R,
-): (p1: MD<P1>, p2: MD<P2>, p3: MD<P3>) => Derivable<R>;
-
-export function lift<P, R>(f: (...ps: P[]) => R): (...ps: Array<P | Derivable<P>>) => Derivable<R> {
-    return (...ps: Array<P | Derivable<P>>) => new _internal.Derivation(f, ps);
+export function lift<PS extends unknown[], R>(
+    f: (...ps: PS) => MaybeFinalState<R>,
+): (...ps: UnwrappableTuple<PS>) => Derivable<R> {
+    return (...ps: UnwrappableTuple<PS>) => derive(() => f(...(ps.map(unwrap) as PS)));
 }
 
-export type MD<P> = P | Derivable<P>;
+export type DerivableTuple<T extends unknown[]> = { [K in keyof T]: Derivable<T[K]> };

--- a/libs/sherlock/.eslintrc.json
+++ b/libs/sherlock/.eslintrc.json
@@ -1,1 +1,5 @@
-{ "extends": "../../.eslintrc.json", "ignorePatterns": ["!**/*"], "rules": {} }
+{
+    "extends": "../../.eslintrc.json",
+    "ignorePatterns": ["!**/*"],
+    "rules": { "@typescript-eslint/no-empty-interface": "off" }
+}

--- a/libs/sherlock/src/index.ts
+++ b/libs/sherlock/src/index.ts
@@ -21,12 +21,17 @@ export type {
     DerivableAtom,
     Fallback,
     LensDescriptor,
+    MaybeFinalState,
     ReactorOptions,
+    SafeUnwrapTuple,
     SettableDerivable,
     State,
     TakeOptionValue,
     ToPromiseOptions,
+    Unwrap,
     Unwrappable,
+    UnwrappableTuple,
+    UnwrapTuple,
 } from './lib/interfaces';
 export { unresolved } from './lib/symbols';
 export { atomic, atomically, inTransaction, transact, transaction } from './lib/transaction';

--- a/libs/sherlock/src/lib/derivable/apply-mixins.ts
+++ b/libs/sherlock/src/lib/derivable/apply-mixins.ts
@@ -1,4 +1,4 @@
-import { Derivable, DerivableAtom, Fallback, SettableDerivable } from '../interfaces';
+import type { Derivable, DerivableAtom, SettableDerivable } from '../interfaces';
 import { Atom } from './atom';
 import { BaseDerivable } from './base-derivable';
 import { PullDataSource } from './data-source';
@@ -32,138 +32,95 @@ import {
 } from './mixins';
 
 declare module './base-derivable' {
-    export interface BaseDerivable<V> {
-        get(): V;
-        getOr<T>(t: Fallback<T>): V | T;
-
-        readonly value: Derivable<V>['value'];
-        readonly resolved: Derivable<V>['resolved'];
-        readonly settable: Derivable<V>['settable'];
-        readonly final: Derivable<V>['final'];
-
-        readonly errored: Derivable<V>['errored'];
-        readonly error: Derivable<V>['error'];
-
-        readonly connected$: Derivable<V>['connected$'];
-
-        readonly derive: Derivable<V>['derive'];
-        readonly map: Derivable<V>['map'];
-        readonly mapState: Derivable<V>['mapState'];
-        readonly flatMap: Derivable<V>['flatMap'];
-        readonly pluck: Derivable<V>['pluck'];
-        readonly fallbackTo: Derivable<V>['fallbackTo'];
-
-        readonly take: Derivable<V>['take'];
-
-        readonly and: Derivable<V>['and'];
-        readonly or: Derivable<V>['or'];
-        readonly not: Derivable<V>['not'];
-        readonly is: Derivable<V>['is'];
-    }
+    export interface BaseDerivable<V> extends Derivable<V> {}
 }
+BaseDerivable.prototype.get = getMethod;
+BaseDerivable.prototype.getOr = getOrMethod;
+BaseDerivable.prototype.derive = deriveMethod;
+BaseDerivable.prototype.map = mapMethod;
+BaseDerivable.prototype.mapState = mapStateMethod;
+BaseDerivable.prototype.flatMap = flatMapMethod;
+BaseDerivable.prototype.pluck = pluckMethod;
+BaseDerivable.prototype.fallbackTo = fallbackToMethod;
+BaseDerivable.prototype.take = takeMethod;
+BaseDerivable.prototype.and = andMethod;
+BaseDerivable.prototype.or = orMethod;
+BaseDerivable.prototype.not = notMethod;
+BaseDerivable.prototype.is = isMethod;
 
-Object.defineProperties(BaseDerivable.prototype, {
-    get: { value: getMethod },
-    getOr: { value: getOrMethod },
+Object.defineProperty(BaseDerivable.prototype, 'settable', { value: false });
 
-    value: { get: valueGetter },
-    resolved: { get: resolvedGetter },
-    settable: { value: false },
-    final: { get: finalGetter },
-
-    errored: { get: erroredGetter },
-    error: { get: errorGetter },
-
-    connected$: { get: connected$Getter },
-
-    derive: { value: deriveMethod },
-    map: { value: mapMethod },
-    mapState: { value: mapStateMethod },
-    flatMap: { value: flatMapMethod },
-    pluck: { value: pluckMethod },
-    fallbackTo: { value: fallbackToMethod },
-
-    take: { value: takeMethod },
-
-    and: { value: andMethod },
-    or: { value: orMethod },
-    not: { value: notMethod },
-    is: { value: isMethod },
-});
+baseDerivableGetter('value', valueGetter);
+baseDerivableGetter('resolved', resolvedGetter);
+baseDerivableGetter('final', finalGetter);
+baseDerivableGetter('errored', erroredGetter);
+baseDerivableGetter('error', errorGetter);
+baseDerivableGetter('connected$', connected$Getter);
 
 declare module './atom' {
-    export interface Atom<V> {
+    export interface Atom<V> extends DerivableAtom<V> {
         value: SettableDerivable<V>['value'];
 
-        readonly unset: DerivableAtom<V>['unset'];
-        readonly setError: DerivableAtom<V>['setError'];
-        readonly setFinal: DerivableAtom<V>['setFinal'];
-        readonly makeFinal: DerivableAtom<V>['makeFinal'];
         readonly map: DerivableAtom<V>['map'];
         readonly mapState: DerivableAtom<V>['mapState'];
 
-        readonly swap: SettableDerivable<V>['swap'];
-        readonly pluck: SettableDerivable<V>['pluck'];
+        pluck: SettableDerivable<V>['pluck'];
     }
 }
 
 declare module './data-source' {
-    export interface PullDataSource<V> {
+    export interface PullDataSource<V> extends SettableDerivable<V> {
         value: SettableDerivable<V>['value'];
 
         readonly map: SettableDerivable<V>['map'];
         readonly mapState: SettableDerivable<V>['mapState'];
 
-        readonly swap: SettableDerivable<V>['swap'];
-        readonly pluck: SettableDerivable<V>['pluck'];
+        pluck: SettableDerivable<V>['pluck'];
     }
 }
 
 declare module './lens' {
-    export interface Lens<V> {
+    export interface Lens<V> extends SettableDerivable<V> {
         value: SettableDerivable<V>['value'];
 
         readonly map: SettableDerivable<V>['map'];
         readonly mapState: SettableDerivable<V>['mapState'];
 
-        readonly swap: SettableDerivable<V>['swap'];
-        readonly pluck: SettableDerivable<V>['pluck'];
-        readonly settable: true;
+        pluck: SettableDerivable<V>['pluck'];
     }
 }
 
 declare module './map' {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    export interface BiMapping<B, V> {
+    export interface BiMapping<B, V> extends DerivableAtom<V> {
         value: SettableDerivable<V>['value'];
 
-        readonly unset: DerivableAtom<V>['unset'];
-        readonly setError: DerivableAtom<V>['setError'];
-        readonly setFinal: DerivableAtom<V>['setFinal'];
-        readonly makeFinal: DerivableAtom<V>['makeFinal'];
         readonly map: DerivableAtom<V>['map'];
         readonly mapState: DerivableAtom<V>['mapState'];
 
-        readonly swap: SettableDerivable<V>['swap'];
-        readonly pluck: SettableDerivable<V>['pluck'];
+        pluck: SettableDerivable<V>['pluck'];
     }
 }
 
-[Atom, PullDataSource, BiMapping, Lens].forEach(c =>
-    Object.defineProperties(c.prototype, {
-        value: { get: valueGetter, set: valueSetter },
-        swap: { value: swapMethod },
-        pluck: { value: settablePluckMethod },
-    }),
-);
-[Atom, BiMapping].forEach(c =>
-    Object.defineProperties(c.prototype, {
-        unset: { value: unsetMethod },
-        setError: { value: setErrorMethod },
-        setFinal: { value: setFinalMethod },
-        makeFinal: { value: makeFinalMethod },
-    }),
-);
-Object.defineProperties(Lens.prototype, {
-    settable: { value: true },
+[Atom, PullDataSource, BiMapping, Lens].forEach(c => {
+    c.prototype.swap = swapMethod;
+    c.prototype.pluck = settablePluckMethod;
+    Object.defineProperty(c.prototype, 'value', { get: valueGetter, set: valueSetter });
 });
+
+[Atom, BiMapping].forEach(c => {
+    c.prototype.unset = unsetMethod;
+    c.prototype.setError = setErrorMethod;
+    c.prototype.setFinal = setFinalMethod;
+    c.prototype.makeFinal = makeFinalMethod;
+});
+
+Object.defineProperty(Lens.prototype, 'settable', { value: true });
+
+// Use a separate functions to define getters for BaseDerivable for correct type-checking (until we get HKT in TypeScript).
+function baseDerivableGetter<K extends keyof BaseDerivable<unknown>>(
+    key: K,
+    get: <V>(this: BaseDerivable<V>) => BaseDerivable<V>[K],
+) {
+    Object.defineProperty(BaseDerivable.prototype, key, { get });
+}

--- a/libs/sherlock/src/lib/derivable/atom.test.ts
+++ b/libs/sherlock/src/lib/derivable/atom.test.ts
@@ -1,5 +1,5 @@
 import { Seq } from 'immutable';
-import { Derivable } from '../interfaces';
+import type { Derivable } from '../interfaces';
 import { react, shouldHaveReactedOnce, shouldNotHaveReacted } from '../reactor/testutils.tests';
 import { txn } from '../transaction/transaction.tests';
 import { Atom } from './atom';

--- a/libs/sherlock/src/lib/derivable/atom.ts
+++ b/libs/sherlock/src/lib/derivable/atom.ts
@@ -1,4 +1,4 @@
-import { DerivableAtom, MaybeFinalState, State } from '../interfaces';
+import type { DerivableAtom, MaybeFinalState, State } from '../interfaces';
 import { finalize, internalGetState, rollback } from '../symbols';
 import { markFinal, recordObservation } from '../tracking';
 import { markObservers, processChangedState, registerForRollback } from '../transaction';

--- a/libs/sherlock/src/lib/derivable/base-derivable.tests.ts
+++ b/libs/sherlock/src/lib/derivable/base-derivable.tests.ts
@@ -1,9 +1,9 @@
 import { fromJS } from 'immutable';
-import { Derivable, DerivableAtom, SettableDerivable } from '../interfaces';
+import type { Derivable, DerivableAtom, SettableDerivable } from '../interfaces';
 import { unresolved } from '../symbols';
 import { config, ErrorWrapper, FinalWrapper } from '../utils';
 import { Atom } from './atom';
-import { BaseDerivable } from './base-derivable';
+import type { BaseDerivable } from './base-derivable';
 import { Derivation } from './derivation';
 import { atom, constant, derive } from './factories';
 import { Mapping } from './map';
@@ -64,7 +64,7 @@ export function testDerivable(factory: Factories | (<V>(atom: Atom<V>) => Deriva
 
     testAccessors(factories, isConstant);
     testBooleanFuncs(factories);
-    testFallbackTo(factories);
+    testFallbackTo(factories, isConstant);
     testFlatMap(factories, isSettable, isAtom);
     testPluck(factories, isSettable, isAtom);
     testTake(factories, isSettable, noRollbackSupport, isAtom);
@@ -319,6 +319,11 @@ export function testDerivable(factory: Factories | (<V>(atom: Atom<V>) => Deriva
     });
 
     describe('#connected$', () => {
+        it('should cache the returned derivable', () => {
+            const d$ = factories.value('a certain value');
+            expect(d$.connected$).toBe(d$.connected$);
+        });
+
         it('should keep observers updated on connected state', () => {
             const d$ = factories.value('a certain value');
             let connected = false;
@@ -536,7 +541,7 @@ export function testDerivable(factory: Factories | (<V>(atom: Atom<V>) => Deriva
     describe('(nested derivables)', () => {
         it('should just work', () => {
             const a$$ = atom(undefined as Derivable<number> | undefined);
-            const a$ = a$$.derive(v => v && v.get());
+            const a$ = a$$.derive(v => v?.get());
 
             expect(a$.get()).toBeUndefined();
 

--- a/libs/sherlock/src/lib/derivable/base-derivable.ts
+++ b/libs/sherlock/src/lib/derivable/base-derivable.ts
@@ -1,4 +1,4 @@
-import { Derivable, MaybeFinalState, SettableDerivable } from '../interfaces';
+import type { Derivable, MaybeFinalState, SettableDerivable } from '../interfaces';
 import { autoCacheMode, connect, disconnect, finalize, internalGetState, observers } from '../symbols';
 import {
     independentTracking,
@@ -72,9 +72,14 @@ export abstract class BaseDerivable<V> implements TrackedObservable, Derivable<V
      */
     abstract readonly version: number;
 
-    connected = false;
+    /** @internal */
+    _connected = false;
+    get connected() {
+        return this._connected;
+    }
     /** @internal */
     _connected$?: SettableDerivable<boolean> = undefined;
+
     [connect]() {
         this.finalized || setConnectionStatus(this, true);
     }
@@ -105,7 +110,7 @@ BaseDerivable.prototype.autoCache = function autoCache() {
 };
 
 function setConnectionStatus(bs: BaseDerivable<unknown>, status: boolean) {
-    bs.connected = status;
+    bs._connected = status;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     bs._connected$ && independentTracking(() => bs._connected$!.set(status));
 }

--- a/libs/sherlock/src/lib/derivable/data-source.test.ts
+++ b/libs/sherlock/src/lib/derivable/data-source.test.ts
@@ -1,11 +1,11 @@
-import { Derivable, MaybeFinalState } from '../interfaces';
+import type { Derivable, MaybeFinalState } from '../interfaces';
 import { react, shouldHaveReactedOnce, shouldNotHaveReacted } from '../reactor/testutils.tests';
 import { connect, dependencies, disconnect } from '../symbols';
 import { basicTransactionsTests } from '../transaction/transaction.tests';
 import { config, FinalWrapper } from '../utils';
 import { testDerivable } from './base-derivable.tests';
 import { PullDataSource } from './data-source';
-import { Derivation } from './derivation';
+import type { Derivation } from './derivation';
 import { atom } from './factories';
 
 describe('derivable/data-source', () => {

--- a/libs/sherlock/src/lib/derivable/data-source.ts
+++ b/libs/sherlock/src/lib/derivable/data-source.ts
@@ -1,4 +1,4 @@
-import { MaybeFinalState, SettableDerivable, State } from '../interfaces';
+import type { MaybeFinalState, SettableDerivable, State } from '../interfaces';
 import { connect, disconnect, emptyCache, internalGetState, rollback } from '../symbols';
 import { independentTracking, recordObservation } from '../tracking';
 import { markObservers, processChangedState, registerForRollback } from '../transaction';

--- a/libs/sherlock/src/lib/derivable/derivation.test.ts
+++ b/libs/sherlock/src/lib/derivable/derivation.test.ts
@@ -1,4 +1,4 @@
-import { Derivable, SettableDerivable } from '../interfaces';
+import type { Derivable, SettableDerivable } from '../interfaces';
 import { unresolved } from '../symbols';
 import { config } from '../utils';
 import { testDerivable } from './base-derivable.tests';

--- a/libs/sherlock/src/lib/derivable/factories.ts
+++ b/libs/sherlock/src/lib/derivable/factories.ts
@@ -1,4 +1,4 @@
-import {
+import type {
     Derivable,
     DerivableAtom,
     LensDescriptor,

--- a/libs/sherlock/src/lib/derivable/lens.ts
+++ b/libs/sherlock/src/lib/derivable/lens.ts
@@ -1,4 +1,4 @@
-import { Derivable, LensDescriptor, SettableDerivable } from '../interfaces';
+import type { Derivable, LensDescriptor, SettableDerivable, UnwrapTuple } from '../interfaces';
 import { atomic } from '../transaction';
 import { augmentStack } from '../utils';
 import { Derivation } from './derivation';
@@ -24,7 +24,7 @@ export class Lens<V, PS extends unknown[] = []> extends Derivation<V, PS> implem
      * @param param0 the get and set functions
      */
     constructor({ get, set }: LensDescriptor<V, any>, args?: PS) {
-        super(get as (this: Derivable<V>, ...args: PS) => V, args);
+        super(get as (this: Derivable<V>, ...args: UnwrapTuple<PS>) => V, args);
         this._setter = set;
     }
 

--- a/libs/sherlock/src/lib/derivable/map.ts
+++ b/libs/sherlock/src/lib/derivable/map.ts
@@ -1,8 +1,8 @@
-import { Derivable, MaybeFinalState, SettableDerivable, State } from '../interfaces';
+import type { Derivable, MaybeFinalState, SettableDerivable, State } from '../interfaces';
 import { connect, disconnect, finalize, unresolved } from '../symbols';
 import { addObserver, independentTracking, removeObserver } from '../tracking';
 import { augmentStack, ErrorWrapper, FinalWrapper } from '../utils';
-import { BaseDerivable } from './base-derivable';
+import type { BaseDerivable } from './base-derivable';
 import { BaseDerivation } from './derivation';
 
 export class Mapping<B, V> extends BaseDerivation<V> implements Derivable<V> {

--- a/libs/sherlock/src/lib/derivable/mixins/accessors.tests.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/accessors.tests.ts
@@ -1,4 +1,4 @@
-import { SettableDerivable } from '../../interfaces';
+import type { SettableDerivable } from '../../interfaces';
 import { internalGetState, observers } from '../../symbols';
 import { addObserver } from '../../tracking';
 import { $, Factories } from '../base-derivable.tests';

--- a/libs/sherlock/src/lib/derivable/mixins/accessors.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/accessors.ts
@@ -1,12 +1,12 @@
-import { Derivable, Fallback, SettableDerivable } from '../../interfaces';
+import type { Derivable, Fallback, SettableDerivable } from '../../interfaces';
 import { unresolved } from '../../symbols';
 import { augmentStack, ErrorWrapper, FinalWrapper } from '../../utils';
 import { Atom } from '../atom';
-import { BaseDerivable } from '../base-derivable';
+import type { BaseDerivable } from '../base-derivable';
 import { derivationStackDepth } from '../derivation';
 import { resolveFallback } from '../resolve-fallback';
 
-export function valueGetter<V>(this: BaseDerivable<V>): V | undefined {
+export function valueGetter<V>(this: Derivable<V>): V | undefined {
     const state = this.getState();
     return state === unresolved || state instanceof ErrorWrapper ? undefined : state;
 }
@@ -15,7 +15,7 @@ export function valueSetter<V>(this: SettableDerivable<V>, newValue: V) {
     return this.set(newValue);
 }
 
-export function getMethod<V>(this: BaseDerivable<V>): V {
+export function getMethod<V>(this: Derivable<V>): V {
     const state = this.getState();
     if (state instanceof ErrorWrapper) {
         // Errors should be augmented at the place they originated (either catched or set).
@@ -30,7 +30,7 @@ export function getMethod<V>(this: BaseDerivable<V>): V {
     throw augmentStack(new Error('Could not get value, derivable is unresolved'), this);
 }
 
-export function getOrMethod<V, T>(this: BaseDerivable<V>, fallback: Fallback<T>): V | T {
+export function getOrMethod<V, T>(this: Derivable<V>, fallback: Fallback<T>): V | T {
     const state = this.getState();
     if (state instanceof ErrorWrapper) {
         throw state.error;
@@ -38,23 +38,23 @@ export function getOrMethod<V, T>(this: BaseDerivable<V>, fallback: Fallback<T>)
     return state === unresolved ? resolveFallback(fallback) : state;
 }
 
-export function resolvedGetter(this: BaseDerivable<unknown>): boolean {
+export function resolvedGetter(this: Derivable<unknown>): boolean {
     return this.getState() !== unresolved;
 }
 
-export function erroredGetter(this: BaseDerivable<unknown>): boolean {
+export function erroredGetter(this: Derivable<unknown>): boolean {
     return this.getState() instanceof ErrorWrapper;
 }
 
-export function errorGetter(this: BaseDerivable<unknown>): unknown {
+export function errorGetter(this: Derivable<unknown>): unknown {
     const state = this.getState();
     return state instanceof ErrorWrapper ? state.error : undefined;
 }
 
 export function connected$Getter(this: BaseDerivable<unknown>): Derivable<boolean> {
-    return this._connected$ || (this._connected$ = new Atom(this.connected));
+    return (this._connected$ ??= new Atom(this.connected));
 }
 
-export function finalGetter(this: BaseDerivable<unknown>): boolean {
+export function finalGetter(this: Derivable<unknown>): boolean {
     return this.getMaybeFinalState() instanceof FinalWrapper;
 }

--- a/libs/sherlock/src/lib/derivable/mixins/boolean-methods.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/boolean-methods.ts
@@ -1,4 +1,4 @@
-import { Derivable, ExcludeFalsies, RestrictToFalsies } from '../../interfaces';
+import type { Derivable, ExcludeFalsies, RestrictToFalsies } from '../../interfaces';
 import { equals } from '../../utils';
 import { isDerivable } from '../typeguards';
 

--- a/libs/sherlock/src/lib/derivable/mixins/fallback-to.tests.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/fallback-to.tests.ts
@@ -1,9 +1,12 @@
+import type { State } from '../../interfaces';
+import { unresolved } from '../../symbols';
+import { ErrorWrapper } from '../../utils';
 import { Atom } from '../atom';
-import { Factories } from '../base-derivable.tests';
+import type { Factories } from '../base-derivable.tests';
 import { atom } from '../factories';
 import { isDerivableAtom, isSettableDerivable } from '../typeguards';
 
-export function testFallbackTo(factories: Factories) {
+export function testFallbackTo(factories: Factories, isConstant: boolean) {
     describe('#fallbackTo', () => {
         it('fallback to the result of the provided function', () => {
             const a$ = factories.unresolved<string>();
@@ -25,6 +28,21 @@ export function testFallbackTo(factories: Factories) {
                 }
             }
         });
+
+        !isConstant &&
+            it('should allow falling back to unresolved or errored', () => {
+                const a$ = factories.unresolved<string>();
+                let fallback: State<string> = 'fallback';
+                const b$ = a$.fallbackTo(() => fallback);
+                expect(b$.value).toBe('fallback');
+                expect(b$.error).toBeUndefined();
+                fallback = unresolved;
+                expect(b$.value).toBeUndefined();
+                expect(b$.error).toBeUndefined();
+                fallback = new ErrorWrapper('error');
+                expect(b$.value).toBeUndefined();
+                expect(b$.error).toBe('error');
+            });
 
         it('fallback to the value of the provided derivable', () => {
             const a$ = factories.unresolved<string>();

--- a/libs/sherlock/src/lib/derivable/mixins/fallback-to.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/fallback-to.ts
@@ -1,10 +1,10 @@
-import { Derivable, Fallback } from '../../interfaces';
+import type { Derivable, Fallback, State } from '../../interfaces';
 import { unresolved } from '../../symbols';
 import { derive } from '../factories';
 import { resolveFallback } from '../resolve-fallback';
 import { isDerivable } from '../typeguards';
 
-export function fallbackToMethod<V, T>(this: Derivable<V>, fallback: Fallback<T>): Derivable<V | T> {
+export function fallbackToMethod<V, T>(this: Derivable<V>, fallback: Fallback<State<T>>): Derivable<V | T> {
     if (isDerivable(fallback)) {
         return derive(() => this.getOr(fallback));
     }

--- a/libs/sherlock/src/lib/derivable/mixins/flat-map.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/flat-map.ts
@@ -1,4 +1,4 @@
-import { Derivable, SettableDerivable, Unwrappable } from '../../interfaces';
+import type { Derivable, SettableDerivable, Unwrappable } from '../../interfaces';
 import { augmentStack } from '../../utils';
 import { lens } from '../factories';
 import { isSettableDerivable } from '../typeguards';

--- a/libs/sherlock/src/lib/derivable/mixins/pluck.tests.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/pluck.tests.ts
@@ -1,5 +1,5 @@
 import { fromJS, Seq } from 'immutable';
-import { DerivableAtom, SettableDerivable } from '../../interfaces';
+import type { DerivableAtom, SettableDerivable } from '../../interfaces';
 import { Atom } from '../atom';
 import { assertSettable, Factories } from '../base-derivable.tests';
 import { atom, constant } from '../factories';

--- a/libs/sherlock/src/lib/derivable/mixins/pluck.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/pluck.ts
@@ -1,4 +1,4 @@
-import { Derivable, SettableDerivable, Unwrappable } from '../../interfaces';
+import type { Derivable, SettableDerivable, Unwrappable } from '../../interfaces';
 import { config } from '../../utils';
 import { lens } from '../factories';
 import { isDerivable } from '../typeguards';

--- a/libs/sherlock/src/lib/derivable/mixins/setters.tests.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/setters.tests.ts
@@ -1,4 +1,4 @@
-import { DerivableAtom } from '../../interfaces';
+import type { DerivableAtom } from '../../interfaces';
 import { assertDerivableAtom, Factories } from '../base-derivable.tests';
 
 export function testDerivableAtomSetters(factories: Factories) {

--- a/libs/sherlock/src/lib/derivable/mixins/setters.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/setters.ts
@@ -1,4 +1,4 @@
-import { DerivableAtom } from '../../interfaces';
+import type { DerivableAtom } from '../../interfaces';
 import { unresolved } from '../../symbols';
 import { ErrorWrapper, FinalWrapper } from '../../utils';
 

--- a/libs/sherlock/src/lib/derivable/mixins/swap.tests.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/swap.tests.ts
@@ -17,7 +17,7 @@ export function testSwap(factories: Factories) {
             expect(a$.get()).toBe('a!');
         });
 
-        function add(a: string, b: string) {
+        function add(a: string, b?: string) {
             return a + b;
         }
         it('should pass any additional parameters to the swap function', () => {

--- a/libs/sherlock/src/lib/derivable/mixins/swap.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/swap.ts
@@ -1,10 +1,10 @@
-import { SettableDerivable } from '../../interfaces';
+import type { SafeUnwrapTuple, SettableDerivable } from '../../interfaces';
 import { safeUnwrap } from '../unwrap';
 
-export function swapMethod<V>(
+export function swapMethod<V, PS extends unknown[]>(
     this: SettableDerivable<V>,
-    f: (oldValue: V | undefined, ...args: any[]) => V,
-    ...args: any[]
+    f: (oldValue: V | undefined, ...args: SafeUnwrapTuple<PS>) => V,
+    ...args: PS
 ) {
-    this.set(f(this.value, ...args.map(safeUnwrap)));
+    this.set(f(this.value, ...(args.map(safeUnwrap) as SafeUnwrapTuple<PS>)));
 }

--- a/libs/sherlock/src/lib/derivable/mixins/take.tests.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/take.tests.ts
@@ -1,4 +1,4 @@
-import { Derivable, DerivableAtom, SettableDerivable, State, TakeOptions } from '../../interfaces';
+import type { Derivable, DerivableAtom, SettableDerivable, State, TakeOptions } from '../../interfaces';
 import { unresolved } from '../../symbols';
 import { txn } from '../../transaction/transaction.tests';
 import { ErrorWrapper } from '../../utils';

--- a/libs/sherlock/src/lib/derivable/mixins/take.ts
+++ b/libs/sherlock/src/lib/derivable/mixins/take.ts
@@ -1,4 +1,4 @@
-import { Derivable, MaybeFinalState, TakeOptions, TakeOptionValue } from '../../interfaces';
+import type { Derivable, MaybeFinalState, TakeOptions, TakeOptionValue } from '../../interfaces';
 import { unresolved } from '../../symbols';
 import { equals, ErrorWrapper, FinalWrapper } from '../../utils';
 import { Atom } from '../atom';

--- a/libs/sherlock/src/lib/derivable/resolve-fallback.ts
+++ b/libs/sherlock/src/lib/derivable/resolve-fallback.ts
@@ -1,4 +1,4 @@
-import { Fallback } from '../interfaces';
+import type { Fallback } from '../interfaces';
 import { unwrap } from './unwrap';
 
 export function resolveFallback<V>(fallback: Fallback<V>): V {

--- a/libs/sherlock/src/lib/derivable/typeguards.ts
+++ b/libs/sherlock/src/lib/derivable/typeguards.ts
@@ -1,4 +1,4 @@
-import { Derivable, DerivableAtom, SettableDerivable } from '../interfaces';
+import type { Derivable, DerivableAtom, SettableDerivable } from '../interfaces';
 import { Atom } from './atom';
 import { BaseDerivable } from './base-derivable';
 import { BiMapping } from './map';

--- a/libs/sherlock/src/lib/derivable/unwrap.ts
+++ b/libs/sherlock/src/lib/derivable/unwrap.ts
@@ -1,4 +1,4 @@
-import { Unwrappable } from '../interfaces';
+import type { Unwrappable } from '../interfaces';
 import { BaseDerivable } from './base-derivable';
 
 /**

--- a/libs/sherlock/src/lib/interfaces.test.ts
+++ b/libs/sherlock/src/lib/interfaces.test.ts
@@ -1,5 +1,5 @@
 import { atom, derive, lens } from './derivable';
-import { Derivable, SettableDerivable } from './interfaces';
+import type { Derivable, SettableDerivable } from './interfaces';
 
 const string$ = atom('value' as const);
 const number$ = atom(1 as const);

--- a/libs/sherlock/src/lib/interfaces.ts
+++ b/libs/sherlock/src/lib/interfaces.ts
@@ -1,5 +1,5 @@
-import { unresolved } from './symbols';
-import { ErrorWrapper, FinalWrapper } from './utils';
+import type { unresolved } from './symbols';
+import type { ErrorWrapper, FinalWrapper } from './utils';
 
 /**
  * Derivable is the base interface of all variants of Sherlock Derivables.
@@ -32,7 +32,7 @@ export interface Derivable<V> {
      *
      * @param fallback fallback to use when the derivable is unresolved
      */
-    fallbackTo<T>(fallback: Fallback<T>): Derivable<V | T>;
+    fallbackTo<T>(fallback: Fallback<State<T>>): Derivable<V | T>;
 
     /**
      * Get the current value of the derivable when applicable, otherwise returns undefined (when in error state or unresolved).
@@ -47,7 +47,7 @@ export interface Derivable<V> {
 
     readonly final: boolean;
 
-    readonly creationStack?: string;
+    readonly creationStack: string | undefined;
 
     /**
      * Indicates whether the derivation is actively used to power a reactor, either directly or indirectly with other derivations in
@@ -185,7 +185,7 @@ export interface SettableDerivable<V> extends Derivable<V> {
      *
      * @param f the swap function
      */
-    swap<PS extends unknown[]>(f: (v: V, ...ps: UnwrapTuple<PS>) => V, ...ps: PS): void;
+    swap<PS extends unknown[]>(f: (v: V, ...ps: SafeUnwrapTuple<PS>) => V, ...ps: PS): void;
 }
 
 export interface DerivableAtom<V> extends SettableDerivable<V> {
@@ -277,7 +277,9 @@ export type Unwrap<T> = T extends Derivable<infer U> ? U : T;
 
 export type UnwrappableTuple<T extends unknown[]> = { [K in keyof T]: Unwrappable<T[K]> };
 
-export type UnwrapTuple<T extends Unwrappable<unknown>[]> = { [K in keyof T]: Unwrap<T[K]> };
+export type UnwrapTuple<T extends unknown[]> = { [K in keyof T]: Unwrap<T[K]> };
+
+export type SafeUnwrapTuple<T extends unknown[]> = { [K in keyof T]: Unwrap<T[K]> | undefined };
 
 export type Fallback<T> = Unwrappable<T> | (() => T);
 

--- a/libs/sherlock/src/lib/reactor/reactor.test.ts
+++ b/libs/sherlock/src/lib/reactor/reactor.test.ts
@@ -1,6 +1,6 @@
 import { atom, Atom, BaseDerivable, constant, derive } from '../derivable';
 import { $ } from '../derivable/base-derivable.tests';
-import { Derivable, SettableDerivable } from '../interfaces';
+import type { Derivable, SettableDerivable } from '../interfaces';
 import { atomically } from '../transaction';
 import { config } from '../utils';
 import { Reactor } from './reactor';

--- a/libs/sherlock/src/lib/reactor/reactor.ts
+++ b/libs/sherlock/src/lib/reactor/reactor.ts
@@ -1,5 +1,5 @@
 import { BaseDerivable } from '../derivable';
-import { ReactorOptions, State, ToPromiseOptions } from '../interfaces';
+import type { ReactorOptions, State, ToPromiseOptions } from '../interfaces';
 import { emptyCache, internalGetState, mark, unresolved } from '../symbols';
 import { addObserver, independentTracking, Observer, removeObserver } from '../tracking';
 import { augmentStack, equals, ErrorWrapper, FinalWrapper, prepareCreationStack, uniqueId } from '../utils';

--- a/libs/sherlock/src/lib/reactor/testutils.tests.ts
+++ b/libs/sherlock/src/lib/reactor/testutils.tests.ts
@@ -1,4 +1,4 @@
-import { Derivable, ReactorOptions } from '../interfaces';
+import type { Derivable, ReactorOptions } from '../interfaces';
 
 let currentReactorTest: { reactions: number; value: unknown };
 export function react<V>(d: Derivable<V>, opts?: Partial<ReactorOptions<V>>) {

--- a/libs/sherlock/src/lib/transaction/transaction.tests.ts
+++ b/libs/sherlock/src/lib/transaction/transaction.tests.ts
@@ -1,5 +1,5 @@
 import { derive } from '../derivable';
-import { SettableDerivable } from '../interfaces';
+import type { SettableDerivable } from '../interfaces';
 import { FinalWrapper } from '../utils';
 import { transact } from './transaction';
 

--- a/libs/sherlock/src/lib/transaction/transaction.ts
+++ b/libs/sherlock/src/lib/transaction/transaction.ts
@@ -1,5 +1,5 @@
 import { finalize, mark, observers, rollback } from '../symbols';
-import { Finalizer, Observable, TrackedObservable, TrackedReactor } from '../tracking';
+import type { Finalizer, Observable, TrackedObservable, TrackedReactor } from '../tracking';
 
 let currentTransaction: Transaction | undefined;
 

--- a/libs/sherlock/src/lib/utils/augment-stack.ts
+++ b/libs/sherlock/src/lib/utils/augment-stack.ts
@@ -1,4 +1,4 @@
-import { MaybeFinalState } from '../interfaces';
+import type { MaybeFinalState } from '../interfaces';
 import { clone } from './clone';
 import { config } from './config';
 import { ErrorWrapper } from './error-wrapper';

--- a/libs/sherlock/src/lib/utils/clone.ts
+++ b/libs/sherlock/src/lib/utils/clone.ts
@@ -17,6 +17,6 @@ function cloneArray<T extends any[]>(obj: T): T {
         return Object.defineProperties(new (obj.constructor as any)(), Object.getOwnPropertyDescriptors(obj));
     } catch (e) {
         // istanbul ignore next: for debug purposes
-        throw Object.assign(new Error('could not clone Array: ' + (e && e.message)), { jse_cause: e });
+        throw Object.assign(new Error('could not clone Array: ' + e?.message), { jse_cause: e });
     }
 }

--- a/libs/sherlock/src/lib/utils/config.ts
+++ b/libs/sherlock/src/lib/utils/config.ts
@@ -1,4 +1,4 @@
-import { Derivable } from '../interfaces';
+import type { Derivable } from '../interfaces';
 import { clone } from './clone';
 
 export const config = {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -21,6 +21,7 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "forceConsistentCasingInFileNames": true,
+        "importsNotUsedAsValues": "error",
         "baseUrl": ".",
         "paths": {
             "@skunkteam/sherlock": ["libs/sherlock/src/index.ts"],


### PR DESCRIPTION
BREAKING CHANGE: The typings now correctly identify the use of `safeUnwrap` for all extra arguments when using `SettableDerivable#swap`, leading to a breaking change in the interface of `SettableDerivable`.