### PR TITLE
fix(sherlock-utils): fix typings-bug in `struct` where readonly arrays…

### DIFF
--- a/libs/ngx-sherfire/ng-package.json
+++ b/libs/ngx-sherfire/ng-package.json
@@ -6,7 +6,7 @@
         "umdModuleIds": {
             "@skunkteam/sherlock": "sherlock",
             "@skunkteam/sherlock-utils": "sherlockUtils",
-            "firebase": "firebase"
+            "firebase/app": "firebase"
         }
     }
 }

--- a/libs/ngx-sherfire/src/lib/firebase-config.service.ts
+++ b/libs/ngx-sherfire/src/lib/firebase-config.service.ts
@@ -1,22 +1,15 @@
-import { Injectable } from '@angular/core';
 import type firebase from 'firebase/app';
 
-@Injectable()
-export class FirebaseConfig {
-    apiKey!: string;
-    authDomain!: string;
-    databaseURL!: string;
-    projectId!: string;
+export abstract class FirebaseConfig {
+    abstract apiKey: string;
+    abstract authDomain: string;
+    abstract databaseURL: string;
+    abstract projectId: string;
     // locationId: string;
-    storageBucket!: string;
-    messagingSenderId!: string;
-    appId!: string;
+    abstract storageBucket: string;
+    abstract messagingSenderId: string;
+    abstract appId: string;
 
-    firestoreSettings?: firebase.firestore.Settings;
-    firestoreEmulator?: { host: string; port: number };
-
-    // istanbul ignore next
-    private constructor() {
-        // this class should not be constructed directly
-    }
+    abstract firestoreSettings?: firebase.firestore.Settings;
+    abstract firestoreEmulator?: { host: string; port: number };
 }

--- a/libs/sherlock-utils/src/lib/struct.test.ts
+++ b/libs/sherlock-utils/src/lib/struct.test.ts
@@ -88,4 +88,33 @@ describe('sherlock-utils/struct', () => {
             ],
         });
     });
+
+    it('should infer the correct types', () => {
+        const a$ = atom('a');
+        const b$ = a$.derive(v => v.length);
+        const object = { a$, b$ };
+        const readonlyObject = { a$, b$ } as const;
+        const array = [a$, b$];
+        const readonlyArray = [a$, b$] as const;
+        const d$ = struct({ object, readonlyObject, array, readonlyArray });
+
+        const result = d$.get();
+
+        type ExpectedType = {
+            object: { a$: string; b$: number };
+            readonlyObject: { a$: string; b$: number };
+            array: readonly (string | number)[];
+            readonlyArray: readonly [string, number];
+        };
+
+        assignableTo<ExpectedType>(result);
+        assignableTo<typeof result>({} as ExpectedType);
+        // @ts-expect-error check that resul is not `any`
+        assignableTo<typeof result>(0 as unknown);
+    });
 });
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function assignableTo<T>(_val: T) {
+    // nothing here
+}

--- a/libs/sherlock-utils/src/lib/struct.test.ts
+++ b/libs/sherlock-utils/src/lib/struct.test.ts
@@ -109,7 +109,7 @@ describe('sherlock-utils/struct', () => {
 
         assignableTo<ExpectedType>(result);
         assignableTo<typeof result>({} as ExpectedType);
-        // @ts-expect-error check that resul is not `any`
+        // @ts-expect-error check that result is not `any`
         assignableTo<typeof result>(0 as unknown);
     });
 });

--- a/libs/sherlock-utils/src/lib/struct.ts
+++ b/libs/sherlock-utils/src/lib/struct.ts
@@ -38,7 +38,7 @@ function deepUnwrap(obj: any): any {
 export type StructUnwrap<T> = T extends Derivable<infer V>
     ? V
     : T extends Record<string, unknown>
-    ? { [K in keyof T]: StructUnwrap<T[K]> }
-    : T extends unknown[]
-    ? { [K in keyof T]: StructUnwrap<T[K]> }
+    ? { readonly [K in keyof T]: StructUnwrap<T[K]> }
+    : T extends readonly unknown[]
+    ? { readonly [K in keyof T]: StructUnwrap<T[K]> }
     : T;


### PR DESCRIPTION
…are not unwrapped in result type