### PR TITLE
update to latest firebase 8.x

### DIFF
--- a/libs/ngx-sherfire/src/lib/firestore/augment-prototypes.ts
+++ b/libs/ngx-sherfire/src/lib/firestore/augment-prototypes.ts
@@ -294,6 +294,21 @@ export interface AugmentedDocumentReference<T = firebase.firestore.DocumentData>
      * provided converter will convert between Firestore data and your custom
      * type U.
      *
+     * Passing in `null` as the converter parameter removes the current
+     * converter.
+     *
+     * @param converter Converts objects to and from Firestore. Passing in
+     * `null` removes the current converter.
+     * @return A DocumentReference<U> that uses the provided converter.
+     */
+    withConverter(converter: null): AugmentedDocumentReference<firebase.firestore.DocumentData>;
+    /**
+     * Applies a custom data converter to this DocumentReference, allowing you
+     * to use your own custom model objects with Firestore. When you call
+     * set(), get(), etc. on the returned DocumentReference instance, the
+     * provided converter will convert between Firestore data and your custom
+     * type U.
+     *
      * @param converter Converts objects to and from Firestore.
      * @return A DocumentReference<U> that uses the provided converter.
      */
@@ -581,6 +596,20 @@ export interface AugmentedCollectionReference<T = firebase.firestore.DocumentDat
      * on the returned CollectionReference instance, the provided converter will
      * convert between Firestore data and your custom type U.
      *
+     * Passing in `null` as the converter parameter removes the current
+     * converter.
+     *
+     * @param converter Converts objects to and from Firestore. Passing in
+     * `null` removes the current converter.
+     * @return A CollectionReference<U> that uses the provided converter.
+     */
+    withConverter(converter: null): AugmentedCollectionReference<firebase.firestore.DocumentData>;
+    /**
+     * Applies a custom data converter to this CollectionReference, allowing you
+     * to use your own custom model objects with Firestore. When you call add()
+     * on the returned CollectionReference instance, the provided converter will
+     * convert between Firestore data and your custom type U.
+     *
      * @param converter Converts objects to and from Firestore.
      * @return A CollectionReference<U> that uses the provided converter.
      */
@@ -836,6 +865,20 @@ export interface AugmentedQuery<T = firebase.firestore.DocumentData>
         onCompletion?: () => void,
     ): () => void;
 
+    /**
+     * Applies a custom data converter to this Query, allowing you to use your
+     * own custom model objects with Firestore. When you call get() on the
+     * returned Query, the provided converter will convert between Firestore
+     * data and your custom type U.
+     *
+     * Passing in `null` as the converter parameter removes the current
+     * converter.
+     *
+     * @param converter Converts objects to and from Firestore. Passing in
+     * `null` removes the current converter.
+     * @return A Query<U> that uses the provided converter.
+     */
+    withConverter(converter: null): AugmentedQuery<firebase.firestore.DocumentData>;
     /**
      * Applies a custom data converter to this Query, allowing you to use your
      * own custom model objects with Firestore. When you call get() on the

--- a/package-lock.json
+++ b/package-lock.json
@@ -2861,102 +2861,104 @@
             }
         },
         "@firebase/analytics": {
-            "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.2.tgz",
-            "integrity": "sha512-4Ceov+rPfOEPIdbjlpTim/wbcUUneIesHag4UOzvmFsRRXqbxLwQpyZQWEbTSriUeU8uTKj9yOW32hsskV9Klg==",
+            "version": "0.6.18",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.18.tgz",
+            "integrity": "sha512-FXNtYDxbs9ynPbzUVuG94BjFPOPpgJ7156660uvCBuKgoBCIVcNqKkJQQ7TH8384fqvGjbjdcgARY9jgAHbtog==",
             "requires": {
-                "@firebase/analytics-types": "0.4.0",
-                "@firebase/component": "0.1.21",
-                "@firebase/installations": "0.4.19",
+                "@firebase/analytics-types": "0.6.0",
+                "@firebase/component": "0.5.6",
+                "@firebase/installations": "0.4.32",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.3.4",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "@firebase/util": "1.3.0",
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/analytics-types": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.4.0.tgz",
-            "integrity": "sha512-Jj2xW+8+8XPfWGkv9HPv/uR+Qrmq37NPYT352wf7MvE9LrstpLVmFg3LqG6MCRr5miLAom5sen2gZ+iOhVDeRA=="
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.6.0.tgz",
+            "integrity": "sha512-kbMawY0WRPyL/lbknBkme4CNLl+Gw+E9G4OpNeXAauqoQiNkBgpIvZYy7BRT4sNGhZbxdxXxXbruqUwDzLmvTw=="
         },
         "@firebase/app": {
-            "version": "0.6.13",
-            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.13.tgz",
-            "integrity": "sha512-xGrJETzvCb89VYbGSHFHCW7O/y067HRxT7MGehUE1xMxdPVBDNayHnxEuKwzfGvXAjVmajXBKFlKxaCWpgSjCQ==",
+            "version": "0.6.30",
+            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.30.tgz",
+            "integrity": "sha512-uAYEDXyK0mmpZ8hWQj5TNd7WVvfsU8PgsqKpGljbFBG/HhsH8KbcykWAAA+c1PqL7dt/dbt0Reh1y9zEdYzMhg==",
             "requires": {
-                "@firebase/app-types": "0.6.1",
-                "@firebase/component": "0.1.21",
+                "@firebase/app-types": "0.6.3",
+                "@firebase/component": "0.5.6",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.3.4",
+                "@firebase/util": "1.3.0",
                 "dom-storage": "2.1.0",
-                "tslib": "^1.11.1",
+                "tslib": "^2.1.0",
                 "xmlhttprequest": "1.8.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
             }
         },
+        "@firebase/app-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.3.2.tgz",
+            "integrity": "sha512-YjpsnV1xVTO1B836IKijRcDeceLgHQNJ/DWa+Vky9UHkm1Mi4qosddX8LZzldaWRTWKX7BN1MbZOLY8r7M/MZQ==",
+            "requires": {
+                "@firebase/app-check-interop-types": "0.1.0",
+                "@firebase/app-check-types": "0.3.1",
+                "@firebase/component": "0.5.6",
+                "@firebase/logger": "0.2.6",
+                "@firebase/util": "1.3.0",
+                "tslib": "^2.1.0"
+            }
+        },
+        "@firebase/app-check-interop-types": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.1.0.tgz",
+            "integrity": "sha512-uZfn9s4uuRsaX5Lwx+gFP3B6YsyOKUE+Rqa6z9ojT4VSRAsZFko9FRn6OxQUA1z5t5d08fY4pf+/+Dkd5wbdbA=="
+        },
+        "@firebase/app-check-types": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.3.1.tgz",
+            "integrity": "sha512-KJ+BqJbdNsx4QT/JIT1yDj5p6D+QN97iJs3GuHnORrqL+DU3RWc9nSYQsrY6Tv9jVWcOkMENXAgDT484vzsm2w=="
+        },
         "@firebase/app-types": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.1.tgz",
-            "integrity": "sha512-L/ZnJRAq7F++utfuoTKX4CLBG5YR7tFO3PLzG1/oXXKEezJ0kRL3CMRoueBEmTCzVb/6SIs2Qlaw++uDgi5Xyg=="
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.3.tgz",
+            "integrity": "sha512-/M13DPPati7FQHEQ9Minjk1HGLm/4K4gs9bR4rzLCWJg64yGtVC0zNg9gDpkw9yc2cvol/mNFxqTtd4geGrwdw=="
         },
         "@firebase/auth": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.2.tgz",
-            "integrity": "sha512-68TlDL0yh3kF8PiCzI8m8RWd/bf/xCLUsdz1NZ2Dwea0sp6e2WAhu0sem1GfhwuEwL+Ns4jCdX7qbe/OQlkVEA==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.8.tgz",
+            "integrity": "sha512-mR0UXG4LirWIfOiCWxVmvz1o23BuKGxeItQ2cCUgXLTjNtWJXdcky/356iTUsd7ZV5A78s2NHeN5tIDDG6H4rg==",
             "requires": {
-                "@firebase/auth-types": "0.10.1"
+                "@firebase/auth-types": "0.10.3"
             }
         },
         "@firebase/auth-interop-types": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.5.tgz",
-            "integrity": "sha512-88h74TMQ6wXChPA6h9Q3E1Jg6TkTHep2+k63OWg3s0ozyGVMeY+TTOti7PFPzq5RhszQPQOoCi59es4MaRvgCw=="
+            "version": "0.1.6",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
+            "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g=="
         },
         "@firebase/auth-types": {
-            "version": "0.10.1",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.1.tgz",
-            "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw=="
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.3.tgz",
+            "integrity": "sha512-zExrThRqyqGUbXOFrH/sowuh2rRtfKHp9SBVY2vOqKWdCX1Ztn682n9WLtlUDsiYVIbBcwautYWk2HyCGFv0OA=="
         },
         "@firebase/component": {
-            "version": "0.1.21",
-            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.21.tgz",
-            "integrity": "sha512-kd5sVmCLB95EK81Pj+yDTea8pzN2qo/1yr0ua9yVi6UgMzm6zAeih73iVUkaat96MAHy26yosMufkvd3zC4IKg==",
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
+            "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
             "requires": {
-                "@firebase/util": "0.3.4",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "@firebase/util": "1.3.0",
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/database": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.9.0.tgz",
-            "integrity": "sha512-j9NgRCsoahvAtQ8LPxMidGsiwsklbtUlDOQ6MhU6/Hk9DVYtEnVT3qSe42xOwBGDfMe191b1B2HsiEOsglWgag==",
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.11.0.tgz",
+            "integrity": "sha512-b/kwvCubr6G9coPlo48PbieBDln7ViFBHOGeVt/bt82yuv5jYZBEYAac/mtOVSxpf14aMo/tAN+Edl6SWqXApw==",
             "requires": {
-                "@firebase/auth-interop-types": "0.1.5",
-                "@firebase/component": "0.1.21",
-                "@firebase/database-types": "0.6.1",
+                "@firebase/auth-interop-types": "0.1.6",
+                "@firebase/component": "0.5.6",
+                "@firebase/database-types": "0.8.0",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.3.4",
+                "@firebase/util": "1.3.0",
                 "faye-websocket": "0.11.3",
-                "tslib": "^1.11.1"
+                "tslib": "^2.1.0"
             },
             "dependencies": {
                 "faye-websocket": {
@@ -2966,67 +2968,49 @@
                     "requires": {
                         "websocket-driver": ">=0.5.1"
                     }
-                },
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
         "@firebase/database-types": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.6.1.tgz",
-            "integrity": "sha512-JtL3FUbWG+bM59iYuphfx9WOu2Mzf0OZNaqWiQ7lJR8wBe7bS9rIm9jlBFtksB7xcya1lZSQPA/GAy2jIlMIkA==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.8.0.tgz",
+            "integrity": "sha512-7IdjAFRfPWyG3b4wcXyghb3Y1CLCSJFZIg1xl5GbTVMttSQFT4B5NYdhsfA34JwAsv5pMzPpjOaS3/K9XJ2KiA==",
             "requires": {
-                "@firebase/app-types": "0.6.1"
+                "@firebase/app-types": "0.6.3",
+                "@firebase/util": "1.3.0"
             }
         },
         "@firebase/firestore": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.1.3.tgz",
-            "integrity": "sha512-+No0hcaJ7hUYD/Vyv8xvEAnIqUQHJAFF5alL3clfyqmYa7bKtffjnZs2Pvm0fEIQ+LK4ovo2be2NmwK4iV0q5g==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.4.1.tgz",
+            "integrity": "sha512-S51XnILdhNt0ZA6bPnbxpqKPI5LatbGY9RQjA2TmATrjSPE3aWndJsLIrutI6aS9K+YFwy5+HLDKVRFYQfmKAw==",
             "requires": {
-                "@firebase/component": "0.1.21",
-                "@firebase/firestore-types": "2.1.0",
+                "@firebase/component": "0.5.6",
+                "@firebase/firestore-types": "2.4.0",
                 "@firebase/logger": "0.2.6",
-                "@firebase/util": "0.3.4",
-                "@firebase/webchannel-wrapper": "0.4.1",
-                "@grpc/grpc-js": "^1.0.0",
-                "@grpc/proto-loader": "^0.5.0",
-                "node-fetch": "2.6.1",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "@firebase/util": "1.3.0",
+                "@firebase/webchannel-wrapper": "0.5.1",
+                "@grpc/grpc-js": "^1.3.2",
+                "@grpc/proto-loader": "^0.6.0",
+                "node-fetch": "2.6.7",
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/firestore-types": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.1.0.tgz",
-            "integrity": "sha512-jietErBWihMvJkqqEquQy5GgoEwzHnMXXC/TsVoe9FPysXm1/AeJS12taS7ZYvenAtyvL/AEJyKrRKRh4adcJQ=="
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.4.0.tgz",
+            "integrity": "sha512-0dgwfuNP7EN6/OlK2HSNSQiQNGLGaRBH0gvgr1ngtKKJuJFuq0Z48RBMeJX9CGjV4TP9h2KaB+KrUKJ5kh1hMg=="
         },
         "@firebase/functions": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.1.tgz",
-            "integrity": "sha512-xNCAY3cLlVWE8Azf+/84OjnaXMoyUstJ3vwVRG0ie22QhsdQuPa1tXTiPX4Tmm+Hbbd/Aw0A/7dkEnuW+zYzaQ==",
+            "version": "0.6.16",
+            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.16.tgz",
+            "integrity": "sha512-KDPjLKSjtR/zEH06YXXbdWTi8gzbKHGRzL/+ibZQA/1MLq0IilfM+1V1Fh8bADsMCUkxkqoc1yiA4SUbH5ajJA==",
             "requires": {
-                "@firebase/component": "0.1.21",
+                "@firebase/component": "0.5.6",
                 "@firebase/functions-types": "0.4.0",
                 "@firebase/messaging-types": "0.5.0",
-                "node-fetch": "2.6.1",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "node-fetch": "2.6.7",
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/functions-types": {
@@ -3035,22 +3019,15 @@
             "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ=="
         },
         "@firebase/installations": {
-            "version": "0.4.19",
-            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.19.tgz",
-            "integrity": "sha512-QqAQzosKVVqIx7oMt5ujF4NsIXgtlTnej4JXGJ8sQQuJoMnt3T+PFQRHbr7uOfVaBiHYhEaXCcmmhfKUHwKftw==",
+            "version": "0.4.32",
+            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.32.tgz",
+            "integrity": "sha512-K4UlED1Vrhd2rFQQJih+OgEj8OTtrtH4+Izkx7ip2bhXSc+unk8ZhnF69D0kmh7zjXAqEDJrmHs9O5fI3rV6Tw==",
             "requires": {
-                "@firebase/component": "0.1.21",
+                "@firebase/component": "0.5.6",
                 "@firebase/installations-types": "0.3.4",
-                "@firebase/util": "0.3.4",
+                "@firebase/util": "1.3.0",
                 "idb": "3.0.2",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/installations-types": {
@@ -3064,23 +3041,16 @@
             "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw=="
         },
         "@firebase/messaging": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.7.3.tgz",
-            "integrity": "sha512-63nOP2SmQJrj9jrhV3K96L5MRKS6AqmFVLX1XbGk6K6lz38ZC4LIoCcHxzUBXY7fCAuZvNmh/YB3pE8B2mTs8A==",
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.8.0.tgz",
+            "integrity": "sha512-hkFHDyVe1kMcY9KEG+prjCbvS6MtLUgVFUbbQqq7JQfiv58E07YCzRUcMrJolbNi/1QHH6Jv16DxNWjJB9+/qA==",
             "requires": {
-                "@firebase/component": "0.1.21",
-                "@firebase/installations": "0.4.19",
+                "@firebase/component": "0.5.6",
+                "@firebase/installations": "0.4.32",
                 "@firebase/messaging-types": "0.5.0",
-                "@firebase/util": "0.3.4",
+                "@firebase/util": "1.3.0",
                 "idb": "3.0.2",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/messaging-types": {
@@ -3089,23 +3059,16 @@
             "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg=="
         },
         "@firebase/performance": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.5.tgz",
-            "integrity": "sha512-oenEOaV/UzvV8XPi8afYQ71RzyrHoBesqOyXqb1TOg7dpU+i+UJ5PS8K64DytKUHTxQl+UJFcuxNpsoy9BpWzw==",
+            "version": "0.4.18",
+            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.18.tgz",
+            "integrity": "sha512-lvZW/TVDne2TyOpWbv++zjRn277HZpbjxbIPfwtnmKjVY1gJ+H77Qi1c2avVIc9hg80uGX/5tNf4pOApNDJLVg==",
             "requires": {
-                "@firebase/component": "0.1.21",
-                "@firebase/installations": "0.4.19",
+                "@firebase/component": "0.5.6",
+                "@firebase/installations": "0.4.32",
                 "@firebase/logger": "0.2.6",
                 "@firebase/performance-types": "0.0.13",
-                "@firebase/util": "0.3.4",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "@firebase/util": "1.3.0",
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/performance-types": {
@@ -3124,23 +3087,16 @@
             }
         },
         "@firebase/remote-config": {
-            "version": "0.1.30",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.30.tgz",
-            "integrity": "sha512-LAfLDcp1AN0V/7AkxBuTKy+Qnq9fKYKxbA5clrXRNVzJbTVnF5eFGsaUOlkes0ESG6lbqKy5ZcDgdl73zBIhAA==",
+            "version": "0.1.43",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.43.tgz",
+            "integrity": "sha512-laNM4MN0CfeSp7XCVNjYOC4DdV6mj0l2rzUh42x4v2wLTweCoJ/kc1i4oWMX9TI7Jw8Am5Wl71Awn1J2pVe5xA==",
             "requires": {
-                "@firebase/component": "0.1.21",
-                "@firebase/installations": "0.4.19",
+                "@firebase/component": "0.5.6",
+                "@firebase/installations": "0.4.32",
                 "@firebase/logger": "0.2.6",
                 "@firebase/remote-config-types": "0.1.9",
-                "@firebase/util": "0.3.4",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "@firebase/util": "1.3.0",
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/remote-config-types": {
@@ -3149,72 +3105,137 @@
             "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
         },
         "@firebase/storage": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.4.2.tgz",
-            "integrity": "sha512-87CrvKrf8kijVekRBmUs8htsNz7N5X/pDhv3BvJBqw8K65GsUolpyjx0f4QJRkCRUYmh3MSkpa5P08lpVbC6nQ==",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.7.1.tgz",
+            "integrity": "sha512-T7uH6lAgNs/Zq8V3ElvR3ypTQSGWon/R7WRM2I5Td/d0PTsNIIHSAGB6q4Au8mQEOz3HDTfjNQ9LuQ07R6S2ug==",
             "requires": {
-                "@firebase/component": "0.1.21",
-                "@firebase/storage-types": "0.3.13",
-                "@firebase/util": "0.3.4",
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "@firebase/component": "0.5.6",
+                "@firebase/storage-types": "0.5.0",
+                "@firebase/util": "1.3.0",
+                "node-fetch": "2.6.7",
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/storage-types": {
-            "version": "0.3.13",
-            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.13.tgz",
-            "integrity": "sha512-pL7b8d5kMNCCL0w9hF7pr16POyKkb3imOW7w0qYrhBnbyJTdVxMWZhb0HxCFyQWC0w3EiIFFmxoz8NTFZDEFog=="
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.5.0.tgz",
+            "integrity": "sha512-6Wv3Lu7s18hsgW7HG4BFwycTquZ3m/C8bjBoOsmPu0TD6M1GKwCzOC7qBdN7L6tRYPh8ipTj5+rPFrmhGfUVKA=="
         },
         "@firebase/util": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.3.4.tgz",
-            "integrity": "sha512-VwjJUE2Vgr2UMfH63ZtIX9Hd7x+6gayi6RUXaTqEYxSbf/JmehLmAEYSuxS/NckfzAXWeGnKclvnXVibDgpjQQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
+            "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
             "requires": {
-                "tslib": "^1.11.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
+                "tslib": "^2.1.0"
             }
         },
         "@firebase/webchannel-wrapper": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.4.1.tgz",
-            "integrity": "sha512-0yPjzuzGMkW1GkrC8yWsiN7vt1OzkMIi9HgxRmKREZl2wnNPOKo/yScTjXf/O57HM8dltqxPF6jlNLFVtc2qdw=="
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.5.1.tgz",
+            "integrity": "sha512-dZMzN0uAjwJXWYYAcnxIwXqRTZw3o14hGe7O6uhwjD1ZQWPVYA5lASgnNskEBra0knVBsOXB4KXg+HnlKewN/A=="
         },
         "@grpc/grpc-js": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.2.5.tgz",
-            "integrity": "sha512-CBCNwedw8McnEBq9jvoiJikws16WN0OiHFejQPovY71XkFWSiIqgvydYiDwpvIYDJmhPQ7qZNzW9BPndhXbx1Q==",
+            "version": "1.5.7",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.5.7.tgz",
+            "integrity": "sha512-RAlSbZ9LXo0wNoHKeUlwP9dtGgVBDUbnBKFpfAv5iSqMG4qWz9um2yLH215+Wow1I48etIa1QMS+WAGmsE/7HQ==",
             "requires": {
-                "@types/node": "^12.12.47",
-                "google-auth-library": "^6.1.1",
-                "semver": "^6.2.0"
+                "@grpc/proto-loader": "^0.6.4",
+                "@types/node": ">=12.12.47"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.19.15",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-                    "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw=="
+                    "version": "17.0.21",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+                    "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
                 }
             }
         },
         "@grpc/proto-loader": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.6.tgz",
-            "integrity": "sha512-DT14xgw3PSzPxwS13auTEwxhMMOoz33DPUKNtmYK/QYbBSpLXJy78FGGs5yVoxVobEqPm4iW9MOIoz0A3bLTRQ==",
+            "version": "0.6.9",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.9.tgz",
+            "integrity": "sha512-UlcCS8VbsU9d3XTXGiEVFonN7hXk+oMXZtoHHG2oSA1/GcDP1q6OUgs20PzHDGizzyi8ufGSUDlk3O2NyY7leg==",
             "requires": {
+                "@types/long": "^4.0.1",
                 "lodash.camelcase": "^4.3.0",
-                "protobufjs": "^6.8.6"
+                "long": "^4.0.0",
+                "protobufjs": "^6.10.0",
+                "yargs": "^16.2.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+                },
+                "cliui": {
+                    "version": "7.0.4",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+                    "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+                    "requires": {
+                        "string-width": "^4.2.0",
+                        "strip-ansi": "^6.0.0",
+                        "wrap-ansi": "^7.0.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+                },
+                "string-width": {
+                    "version": "4.2.3",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.1"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "6.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+                            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                            "requires": {
+                                "ansi-regex": "^5.0.1"
+                            }
+                        }
+                    }
+                },
+                "wrap-ansi": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+                    "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+                    "requires": {
+                        "ansi-styles": "^4.0.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0"
+                    }
+                },
+                "y18n": {
+                    "version": "5.0.8",
+                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+                    "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+                },
+                "yargs": {
+                    "version": "16.2.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+                    "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+                    "requires": {
+                        "cliui": "^7.0.2",
+                        "escalade": "^3.1.1",
+                        "get-caller-file": "^2.0.5",
+                        "require-directory": "^2.1.1",
+                        "string-width": "^4.2.0",
+                        "y18n": "^5.0.5",
+                        "yargs-parser": "^20.2.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "20.2.9",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+                    "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
+                }
             }
         },
         "@istanbuljs/load-nyc-config": {
@@ -4688,14 +4709,6 @@
             "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
             "dev": true
         },
-        "abort-controller": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-            "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-            "requires": {
-                "event-target-shim": "^5.0.0"
-            }
-        },
         "accepts": {
             "version": "1.3.7",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -4748,14 +4761,6 @@
             "requires": {
                 "loader-utils": "^2.0.0",
                 "regex-parser": "^2.2.11"
-            }
-        },
-        "agent-base": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-            "requires": {
-                "debug": "4"
             }
         },
         "aggregate-error": {
@@ -4819,14 +4824,12 @@
         "ansi-regex": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-            "dev": true
+            "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
             "requires": {
                 "color-convert": "^2.0.1"
             }
@@ -5363,7 +5366,8 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
         },
         "batch": {
             "version": "0.6.1",
@@ -5385,11 +5389,6 @@
             "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
             "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
             "dev": true
-        },
-        "bignumber.js": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
-            "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
         },
         "binary-extensions": {
             "version": "2.2.0",
@@ -5638,11 +5637,6 @@
                 "ieee754": "^1.1.4",
                 "isarray": "^1.0.0"
             }
-        },
-        "buffer-equal-constant-time": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
         },
         "buffer-from": {
             "version": "1.1.1",
@@ -6193,7 +6187,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
             "requires": {
                 "color-name": "~1.1.4"
             }
@@ -6201,8 +6194,7 @@
         "color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
         },
         "color-string": {
             "version": "1.5.4",
@@ -7546,6 +7538,7 @@
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
             "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "dev": true,
             "requires": {
                 "ms": "2.1.2"
             }
@@ -8019,14 +8012,6 @@
                 "safer-buffer": "^2.1.0"
             }
         },
-        "ecdsa-sig-formatter": {
-            "version": "1.0.11",
-            "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-            "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -8080,8 +8065,7 @@
         "emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-            "dev": true
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
         "emojis-list": {
             "version": "3.0.0",
@@ -8216,8 +8200,7 @@
         "escalade": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-            "dev": true
+            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
         },
         "escape-html": {
             "version": "1.0.3",
@@ -8808,11 +8791,6 @@
             "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
             "dev": true
         },
-        "event-target-shim": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-            "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-        },
         "eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -9030,7 +9008,8 @@
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -9166,11 +9145,6 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
-        },
-        "fast-text-encoding": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-            "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
         },
         "fastparse": {
             "version": "1.1.2",
@@ -9337,24 +9311,25 @@
             }
         },
         "firebase": {
-            "version": "8.2.4",
-            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.2.4.tgz",
-            "integrity": "sha512-+skMZY0kXKCFVAlbwoKnRDfOhmg9rp2lDZBJk/h4PYxh/joPNTXYCKFYqUkXfwSW4jQBlLP+PtjrZKeedg6mdA==",
+            "version": "8.10.1",
+            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.10.1.tgz",
+            "integrity": "sha512-84z/zqF8Y5IpUYN8nREZ/bxbGtF5WJDOBy4y0hAxRzGpB5+2tw9PQgtTnUzk6MQiVEf/WOniMUL3pCVXKsxALw==",
             "requires": {
-                "@firebase/analytics": "0.6.2",
-                "@firebase/app": "0.6.13",
-                "@firebase/app-types": "0.6.1",
-                "@firebase/auth": "0.16.2",
-                "@firebase/database": "0.9.0",
-                "@firebase/firestore": "2.1.3",
-                "@firebase/functions": "0.6.1",
-                "@firebase/installations": "0.4.19",
-                "@firebase/messaging": "0.7.3",
-                "@firebase/performance": "0.4.5",
+                "@firebase/analytics": "0.6.18",
+                "@firebase/app": "0.6.30",
+                "@firebase/app-check": "0.3.2",
+                "@firebase/app-types": "0.6.3",
+                "@firebase/auth": "0.16.8",
+                "@firebase/database": "0.11.0",
+                "@firebase/firestore": "2.4.1",
+                "@firebase/functions": "0.6.16",
+                "@firebase/installations": "0.4.32",
+                "@firebase/messaging": "0.8.0",
+                "@firebase/performance": "0.4.18",
                 "@firebase/polyfill": "0.3.36",
-                "@firebase/remote-config": "0.1.30",
-                "@firebase/storage": "0.4.2",
-                "@firebase/util": "0.3.4"
+                "@firebase/remote-config": "0.1.43",
+                "@firebase/storage": "0.7.1",
+                "@firebase/util": "1.3.0"
             }
         },
         "flat": {
@@ -9693,34 +9668,6 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
-        "gaxios": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
-            "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
-            "requires": {
-                "abort-controller": "^3.0.0",
-                "extend": "^3.0.2",
-                "https-proxy-agent": "^5.0.0",
-                "is-stream": "^2.0.0",
-                "node-fetch": "^2.3.0"
-            },
-            "dependencies": {
-                "is-stream": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
-                }
-            }
-        },
-        "gcp-metadata": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
-            "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
-            "requires": {
-                "gaxios": "^4.0.0",
-                "json-bigint": "^1.0.0"
-            }
-        },
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -9730,8 +9677,7 @@
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-intrinsic": {
             "version": "1.0.2",
@@ -10090,37 +10036,6 @@
                 "slash": "^3.0.0"
             }
         },
-        "google-auth-library": {
-            "version": "6.1.6",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
-            "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
-            "requires": {
-                "arrify": "^2.0.0",
-                "base64-js": "^1.3.0",
-                "ecdsa-sig-formatter": "^1.0.11",
-                "fast-text-encoding": "^1.0.0",
-                "gaxios": "^4.0.0",
-                "gcp-metadata": "^4.2.0",
-                "gtoken": "^5.0.4",
-                "jws": "^4.0.0",
-                "lru-cache": "^6.0.0"
-            },
-            "dependencies": {
-                "arrify": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
-                }
-            }
-        },
-        "google-p12-pem": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
-            "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
-            "requires": {
-                "node-forge": "^0.10.0"
-            }
-        },
         "graceful-fs": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
@@ -10133,16 +10048,6 @@
             "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
             "dev": true,
             "optional": true
-        },
-        "gtoken": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
-            "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
-            "requires": {
-                "gaxios": "^4.0.0",
-                "google-p12-pem": "^3.0.3",
-                "jws": "^4.0.0"
-            }
         },
         "handle-thing": {
             "version": "2.0.1",
@@ -10562,15 +10467,6 @@
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
-        },
-        "https-proxy-agent": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-            "requires": {
-                "agent-base": "6",
-                "debug": "4"
-            }
         },
         "human-signals": {
             "version": "1.1.1",
@@ -12764,14 +12660,6 @@
             "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
-        "json-bigint": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
-            "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
-            "requires": {
-                "bignumber.js": "^9.0.0"
-            }
-        },
         "json-parse-better-errors": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -12854,25 +12742,6 @@
                 "extsprintf": "1.3.0",
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
-            }
-        },
-        "jwa": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
-            "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
-            "requires": {
-                "buffer-equal-constant-time": "1.0.1",
-                "ecdsa-sig-formatter": "1.0.11",
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "jws": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
-            "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
-            "requires": {
-                "jwa": "^2.0.0",
-                "safe-buffer": "^5.0.1"
             }
         },
         "karma-source-map-support": {
@@ -13152,6 +13021,7 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+            "dev": true,
             "requires": {
                 "yallist": "^4.0.0"
             }
@@ -13605,7 +13475,8 @@
         "ms": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+            "dev": true
         },
         "multicast-dns": {
             "version": "6.2.3",
@@ -13965,14 +13836,39 @@
             "dev": true
         },
         "node-fetch": {
-            "version": "2.6.1",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-            "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+                    "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+                },
+                "webidl-conversions": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+                    "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+                },
+                "whatwg-url": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+                    "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+                    "requires": {
+                        "tr46": "~0.0.3",
+                        "webidl-conversions": "^3.0.0"
+                    }
+                }
+            }
         },
         "node-forge": {
             "version": "0.10.0",
             "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
+            "dev": true
         },
         "node-int64": {
             "version": "0.4.0",
@@ -15635,9 +15531,9 @@
             }
         },
         "protobufjs": {
-            "version": "6.10.2",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.2.tgz",
-            "integrity": "sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==",
+            "version": "6.11.2",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.2.tgz",
+            "integrity": "sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==",
             "requires": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
@@ -15650,14 +15546,14 @@
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.0",
                 "@types/long": "^4.0.1",
-                "@types/node": "^13.7.0",
+                "@types/node": ">=13.7.0",
                 "long": "^4.0.0"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "13.13.40",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.40.tgz",
-                    "integrity": "sha512-eKaRo87lu1yAXrzEJl0zcJxfUMDT5/mZalFyOkT44rnQps41eS2pfWzbaulSPpQLFNy29bFqn+Y5lOTL8ATlEQ=="
+                    "version": "17.0.21",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
+                    "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ=="
                 }
             }
         },
@@ -16197,8 +16093,7 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-            "dev": true
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "require-from-string": {
             "version": "2.0.2",
@@ -16548,7 +16443,8 @@
         "safe-buffer": {
             "version": "5.2.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true
         },
         "safe-regex": {
             "version": "1.1.0",
@@ -16794,7 +16690,8 @@
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+            "dev": true
         },
         "semver-dsl": {
             "version": "1.0.1",
@@ -17889,7 +17786,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
             "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-            "dev": true,
             "requires": {
                 "ansi-regex": "^5.0.0"
             }
@@ -20708,7 +20604,8 @@
         "yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+            "dev": true
         },
         "yaml": {
             "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "@angular/platform-browser": "^11.0.0",
         "@angular/platform-browser-dynamic": "^11.0.0",
         "@angular/router": "^11.0.0",
-        "firebase": "^8.2.4",
+        "firebase": "^8.10.1",
         "rxjs": "^6.0.0",
         "tslib": "^2.0.0",
         "zone.js": "^0.10.2"


### PR DESCRIPTION
Update to latest firebase 8.x as firestore introduced `withConvter(null)` to some classes. Since we have augmented types that have to be compatible with the original types, we also have to add the `withConvter(null)` signatures.
Upgrading to a new major version of firebase/firestore is for another day as the types in the new major version have been totally rearranged. In fact, they no longer use classes but many independent functions which should make our life easier.