### PR TITLE
fix(ngx-sherlock): fix change detection of ValuePipe on errored/unresolved derivables

### DIFF
--- a/libs/ngx-sherlock/src/lib/value.pipe.ts
+++ b/libs/ngx-sherlock/src/lib/value.pipe.ts
@@ -40,7 +40,7 @@ export class ValuePipe implements PipeTransform, OnDestroy {
     private readonly output$ = this.input$.derive(unwrap);
     private readonly stop = materialize(this.output$).react(
         m => {
-            if (m.errored) console.error('Error in input-derivable to ValuePipe:', this.output$.error);
+            if (m.errored) console.error('Error in input-derivable to ValuePipe:', m.error);
             this.changeDetector.markForCheck();
         },
         { skipFirst: true },


### PR DESCRIPTION
Fixes a bug where `markForCheck` was not being called when an input derivable switched between resolved, unresolved and errored states.