### PR TITLE
feat(sherlock-utils): add new `parallelStruct` util

### DIFF
--- a/libs/sherlock-utils/src/lib/struct.ts
+++ b/libs/sherlock-utils/src/lib/struct.ts
@@ -1,4 +1,4 @@
-import { Derivable, derive, isDerivable, utils } from '@skunkteam/sherlock';
+import { Derivable, derive, isDerivable, unresolved, utils } from '@skunkteam/sherlock';
 
 /**
  * Converts a map or array of Derivables or any nested structure containing maps, arrays and Derivables into a single
@@ -12,23 +12,59 @@ import { Derivable, derive, isDerivable, utils } from '@skunkteam/sherlock';
  *
  * It only touches Arrays, plain Objects and Derivables, the rest is simply returned inside the Derivable as-is.
  *
- * @param obj the object to deepunwrap into a derivable
+ * This function unwraps Derivables one by one, waiting for a Derivable to become resolved before looking for the next
+ * Derivable.
+ *
+ * @param input the object to deepunwrap into a derivable
  */
 export function struct<T>(input: T): Derivable<StructUnwrap<T>> {
-    return (isDerivable(input) ? input : derive(deepUnwrap, input)) as Derivable<StructUnwrap<T>>;
+    return (isDerivable(input) ? input : derive(deepUnwrapSerial, input)) as Derivable<StructUnwrap<T>>;
 }
 
-function deepUnwrap(obj: any): any {
+/**
+ * Converts a map or array of Derivables or any nested structure containing maps, arrays and Derivables into a single
+ * Derivable with all nested Derivables unwrapped into it.
+ *
+ * ```typescript
+ * const obj = { key1: atom(123), key2: atom(456) };
+ * const obj$ = struct(obj);
+ * expect(obj$.get()).to.deep.equal({ key1: 123, key2: 456 });
+ * ```
+ *
+ * It only touches Arrays, plain Objects and Derivables, the rest is simply returned inside the Derivable as-is.
+ *
+ * This function eagerly activates Derivables in the input, so they get activated ("connected") in parallel.
+ *
+ * @param input the object to deepunwrap into a derivable
+ */
+export function parallelStruct<T>(input: T): Derivable<StructUnwrap<T>> {
+    return (isDerivable(input) ? input : derive(deepUnwrapParallel, input)) as Derivable<StructUnwrap<T>>;
+}
+
+function deepUnwrapSerial(obj: any) {
+    return deepUnwrap(obj, d$ => d$.get());
+}
+
+function deepUnwrapParallel(obj: any) {
+    let resolved = true;
+    const value = deepUnwrap(obj, d$ => {
+        resolved &&= d$.resolved;
+        return d$.value;
+    });
+    return resolved ? value : unresolved;
+}
+
+function deepUnwrap(obj: any, handleDerivable: (d$: Derivable<unknown>) => unknown): any {
     if (isDerivable(obj)) {
-        return obj.get();
+        return handleDerivable(obj);
     }
     if (Array.isArray(obj)) {
-        return obj.map(deepUnwrap);
+        return obj.map(element => deepUnwrap(element, handleDerivable));
     }
     if (utils.isPlainObject(obj)) {
         const result: Record<string, unknown> = {};
         for (const key of Object.keys(obj)) {
-            result[key] = deepUnwrap(obj[key]);
+            result[key] = deepUnwrap(obj[key], handleDerivable);
         }
         return result;
     }


### PR DESCRIPTION
The new `parallelStruct` util does the same as the existing `struct` util, the only difference being that it activates the nested Derivables in parallel (eagerly).