### PR TITLE
feat(ngx-sherlock): add ability to set firestore database id

### DIFF
--- a/libs/ngx-sherfire/src/lib/firebase-config.service.ts
+++ b/libs/ngx-sherfire/src/lib/firebase-config.service.ts
@@ -3,6 +3,7 @@ import type { FirestoreSettings } from 'firebase/firestore';
 
 export abstract class FirebaseConfig {
     abstract firestoreSettings?: FirestoreSettings;
+    abstract firestoreDatabaseId?: string;
     abstract firestoreEmulator?: { host: string; port: number };
     abstract appSettings?: FirebaseAppSettings;
 }

--- a/libs/ngx-sherfire/src/lib/firestore/sherfire-firestore.service.ts
+++ b/libs/ngx-sherfire/src/lib/firestore/sherfire-firestore.service.ts
@@ -11,8 +11,8 @@ export interface SherfireFirestore extends Firestore {}
     providedIn: NgxSherfireModule,
     useFactory: () =>
         inject(NgZone).runOutsideAngular(() => {
-            const { firestoreEmulator, firestoreSettings } = inject(FirebaseConfig);
-            const firestore = initializeFirestore(inject(SherfireApp), firestoreSettings ?? {});
+            const { firestoreEmulator, firestoreDatabaseId, firestoreSettings } = inject(FirebaseConfig);
+            const firestore = initializeFirestore(inject(SherfireApp), firestoreSettings ?? {}, firestoreDatabaseId);
             if (firestoreEmulator) {
                 connectFirestoreEmulator(firestore, firestoreEmulator.host, firestoreEmulator.port);
             }


### PR DESCRIPTION
For situation where a named database is used (aka a firestore database other than `(default)`)